### PR TITLE
refs [TASK][33689] init ui detail

### DIFF
--- a/app/src/main/java/com/sun/cookbook/screen/detail/DetailRecipeFragment.kt
+++ b/app/src/main/java/com/sun/cookbook/screen/detail/DetailRecipeFragment.kt
@@ -5,11 +5,26 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentManager
+import com.bumptech.glide.Glide
 import com.sun.cookbook.R
 import com.sun.cookbook.data.model.RecipeDetail
+import com.sun.cookbook.data.model.Step
+import com.sun.cookbook.data.source.RecipeRepository
+import com.sun.cookbook.screen.detail.step.StepPagerAdapter
+import com.sun.cookbook.utils.Constant
+import kotlinx.android.synthetic.main.fragment_detail_recipe.*
+import kotlinx.android.synthetic.main.fragment_detail_recipe.textTitleDish
+import kotlinx.android.synthetic.main.fragment_home.*
+import kotlinx.android.synthetic.main.item_recipe.*
 
 class DetailRecipeFragment : Fragment(), ViewContactDetail.View {
+
+    private val detailPresenter: ViewContactDetail.Presenter by lazy {
+        DetailPresenter(RecipeRepository.getInstance())
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -18,13 +33,45 @@ class DetailRecipeFragment : Fragment(), ViewContactDetail.View {
         return inflater.inflate(R.layout.fragment_detail_recipe, container, false)
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initPresenter()
+        imgBack.setOnClickListener {
+            fragmentManager?.popBackStack(0, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
+    }
+
     override fun getRecipeDetailSuccess(recipes: RecipeDetail) {
+        Glide.with(this)
+            .load(recipes.image)
+            .into(imageDish)
+        textTitleDish.text = recipes.title
+        textTime.text = context?.getString(R.string.ready_in_minute, recipes.timeCook.toString())
+        recipes.step?.run {
+            initStep(this)
+        }
     }
 
     override fun onError(exception: Exception?) {
+        Toast.makeText(context, exception?.message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun initPresenter() {
+        detailPresenter.apply {
+            setView(this@DetailRecipeFragment)
+            arguments?.getInt(BUNDLE_ID_RECIPE)?.let {
+                getRecipes(it)
+            }
+            onStart()
+        }
+    }
+
+    private fun initStep(step: MutableList<Step>) {
+        viewPagerStep.adapter = StepPagerAdapter(step)
     }
 
     companion object {
+
         private const val BUNDLE_ID_RECIPE = "BUNDLE_ID_RECIPE"
 
         fun newInstance(idRecipe: Int) = DetailRecipeFragment().apply {

--- a/app/src/main/java/com/sun/cookbook/screen/detail/step/ItemStepViewHolder.kt
+++ b/app/src/main/java/com/sun/cookbook/screen/detail/step/ItemStepViewHolder.kt
@@ -1,0 +1,20 @@
+package com.sun.cookbook.screen.detail.step
+
+import android.annotation.SuppressLint
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.sun.cookbook.R
+import com.sun.cookbook.data.model.Step
+import kotlinx.android.synthetic.main.item_step_detail.view.*
+
+class ItemStepViewHolder(itemView: View) :
+    RecyclerView.ViewHolder(itemView) {
+
+    @SuppressLint("SetTextI18n")
+    fun binData(steps: Step) {
+        itemView.apply {
+            textNumberStep.text = context.getString(R.string.step, steps.number.toString())
+            textStep.text = "''" + steps.step + "''"
+        }
+    }
+}

--- a/app/src/main/java/com/sun/cookbook/screen/detail/step/StepPagerAdapter.kt
+++ b/app/src/main/java/com/sun/cookbook/screen/detail/step/StepPagerAdapter.kt
@@ -1,0 +1,23 @@
+package com.sun.cookbook.screen.detail.step
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.sun.cookbook.R
+import com.sun.cookbook.data.model.Step
+
+class StepPagerAdapter(private val listItemStep: MutableList<Step>) :
+    RecyclerView.Adapter<ItemStepViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemStepViewHolder {
+        return ItemStepViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.item_step_detail, parent, false)
+        )
+    }
+
+    override fun getItemCount() = listItemStep.size
+
+    override fun onBindViewHolder(holder: ItemStepViewHolder, position: Int) {
+        holder.binData(listItemStep[position])
+    }
+}

--- a/app/src/main/java/com/sun/cookbook/screen/home/HomeFragment.kt
+++ b/app/src/main/java/com/sun/cookbook/screen/home/HomeFragment.kt
@@ -58,8 +58,7 @@ class HomeFragment : Fragment(), ViewContactHome.View {
     }
 
     override fun onError(exception: Exception?) {
-        if (exception == null) Toast.makeText(context, null, Toast.LENGTH_SHORT).show()
-        else Toast.makeText(context, exception.message, Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, exception?.message, Toast.LENGTH_SHORT).show()
     }
 
     private fun initPresenter() {

--- a/app/src/main/res/drawable-v24/bg_step.xml
+++ b/app/src/main/res/drawable-v24/bg_step.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:bottomLeftRadius="20dp"
+        android:bottomRightRadius="20dp"
+        android:topLeftRadius="20dp"
+        android:topRightRadius="20dp" />
+    <solid android:color="#F2F2F2"/>
+</shape>

--- a/app/src/main/res/layout/fragment_detail_recipe.xml
+++ b/app/src/main/res/layout/fragment_detail_recipe.xml
@@ -1,8 +1,190 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/color_0A172C"
     android:clickable="true"
     android:focusable="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/imgFavourite"
+            android:layout_width="@dimen/dp_30"
+            android:layout_height="@dimen/dp_30"
+            android:layout_margin="@dimen/dp_12"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_favourite"
+            android:translationZ="@dimen/dp_10"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/imgBack"
+            android:layout_width="@dimen/dp_30"
+            android:layout_height="@dimen/dp_30"
+            android:layout_marginStart="@dimen/dp_12"
+            android:layout_marginTop="@dimen/dp_10"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_back"
+            android:translationZ="@dimen/dp_10"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cardTopDetail"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="361:240"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <ImageView
+                    android:id="@+id/imageDish"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:scaleType="fitXY"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:id="@+id/viewShape"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dp_25"
+                    android:alpha="0.5"
+                    app:layout_constraintWidth_percent="0.5"
+                    android:background="@drawable/bg_shape_detail"
+                    android:translationZ="@dimen/dp_10"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
+                <TextView
+                    android:id="@+id/textTime"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/sp_13"
+                    android:textStyle="italic"
+                    android:translationZ="@dimen/dp_10"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="@id/viewShape"
+                    app:layout_constraintStart_toStartOf="@id/viewShape" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/textTitleDish"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/dp_27"
+            android:layout_marginTop="@dimen/dp_10"
+            android:textColor="@color/white"
+            android:textSize="@dimen/sp_22"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cardTopDetail" />
+
+        <TextView
+            android:id="@+id/textIngredient"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/dp_24"
+            android:layout_marginTop="@dimen/dp_27"
+            android:background="@drawable/bg_buton_detail1"
+            android:paddingTop="@dimen/dp_4"
+            android:text="@string/ingredient"
+            android:textAlignment="center"
+            android:textAllCaps="true"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/sp_12"
+            android:textStyle="italic"
+            app:layout_constraintEnd_toStartOf="@+id/textNutrient"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textTitleDish"
+            app:layout_constraintWidth_percent="0.35" />
+
+        <TextView
+            android:id="@+id/textNutrient"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/dp_24"
+            android:layout_marginTop="@dimen/dp_27"
+            android:background="@drawable/bg_button_detail"
+            android:paddingTop="@dimen/dp_4"
+            android:text="@string/nutrient"
+            android:textAlignment="center"
+            android:textAllCaps="true"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/sp_12"
+            android:textStyle="italic"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/textIngredient"
+            app:layout_constraintTop_toBottomOf="@+id/textTitleDish"
+            app:layout_constraintWidth_percent="0.35" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_20"
+            android:textColor="@color/white"
+            android:textSize="@dimen/sp_14"
+            android:textStyle="italic"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textIngredient" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPagerStep"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/dp_30"
+            app:layout_constraintDimensionRatio="320:200"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textNutrient" />
+
+        <TextView
+            android:id="@+id/textSimilarRecipe"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/dp_18"
+            android:layout_marginTop="@dimen/dp_20"
+            android:textColor="@color/white"
+            android:textStyle="italic"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/viewPagerStep" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewSimilarRecipe"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_23"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textSimilarRecipe"
+            app:layout_constraintWidth_percent="0.93"
+            tools:itemCount="5"
+            tools:listitem="@layout/item_recipe" />
+
+        <FrameLayout
+            android:id="@+id/bottomSheetContainer"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.4"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/item_step_detail.xml
+++ b/app/src/main/res/layout/item_step_detail.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/dp_20"
+    android:background="@drawable/bg_step"
+    android:padding="@dimen/dp_5">
+
+    <TextView
+        android:id="@+id/textNumberStep"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/dp_15"
+        android:gravity="center"
+        android:textAllCaps="true"
+        android:textColor="@android:color/black"
+        android:textSize="@dimen/sp_20"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/dp_30"
+        android:layout_marginBottom="@dimen/dp_30"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/textStep"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/dp_20"
+            android:layout_marginTop="@dimen/dp_20"
+            android:layout_marginEnd="@dimen/dp_20"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:textSize="@dimen/sp_16"
+            android:textStyle="italic" />
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -37,5 +37,6 @@
     <dimen name="sp_20">20sp</dimen>
     <dimen name="sp_22">22sp</dimen>
     <dimen name="sp_28">28sp</dimen>
+    <dimen name="sp_16">16sp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">BookCook</string>
     <string name="title_header">cookbook.com</string>
-    <string name="step">Steps :</string>
+    <string name="step">Step : %s</string>
     <string name="top_recipe">Top recipes</string>
     <string name="ingredient">ingredient</string>
     <string name="nutrient">nutrient</string>
@@ -12,5 +12,4 @@
     <string name="top_recipes">Top recipes</string>
     <string name="ready_in_minute">Ready in Minute : %s</string>
     <string name="spoonacular_score">Spoonacular score : %s</string>
-    <string name="steps">Steps :</string>
 </resources>


### PR DESCRIPTION
## Related Tickets
- [#Task 33689: Content](https://edu-redmine.sun-asterisk.vn/issues/33689)
## WHAT
- Create UI Fragment Detail (Image, Poster, title, time cook, viewpager step, recylerview similar reicpe)
- Show list step by viewpager2
## Evidence (Screenshot or Video)
![image](https://user-images.githubusercontent.com/73867223/106549670-0b7f3680-6544-11eb-80e5-ce276eb2ac2d.png)

## Review Checklist

Category | View Point | Description | Expected Reviewer Answer | Self review | Reviewer2 (name)
--- | --- | --- | --- | --- | ---
Conventions | Does the code follow Sun* coding style and coding conventions? | https://github.com/framgia/coding-standards/tree/master/eng/android | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Does the ticket follow Sun* Redmine working process?  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md| YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Documentation | Is there any incomplete code? If so, should it be removed or flagged with a suitable marker like ‘TODO’? |  | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
## Notes (Optional)
